### PR TITLE
Remove print statements

### DIFF
--- a/Sources/SwiftOpenAPI/Encoders/TypeRevision/TypeRevisionDecoder.swift
+++ b/Sources/SwiftOpenAPI/Encoders/TypeRevision/TypeRevisionDecoder.swift
@@ -280,7 +280,6 @@ private struct TypeRevisionSingleValueDecodingContainer: SingleValueDecodingCont
 
 	func decode<T: Decodable>(_ type: T.Type) throws -> T {
 		guard let t = _decodeIfPresent(type, optional: false) else {
-			print("Failed to decode \(type)")
 			throw AnyError()
 		}
 		return t
@@ -521,9 +520,6 @@ private struct TypeRevisionKeyedDecodingContainer<Key: CodingKey>: KeyedDecoding
 		value.isOptional = optional
 		result[str(key)] = value
 		guard let t = decodable as? T else {
-			if !optional {
-				print("Failed to decode \(type) for key \(key.stringValue)")
-			}
 			throw AnyError()
 		}
 		return t


### PR DESCRIPTION
We [noticed `Failed to decode` messages](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2716) recently appearing in our logs and I believe I've tracked this down to line 283 in `TypeRevisionDecoder`.

This started happening when we updated from SwiftOpenAPI 2.18.1 to 2.18.3. The print isn't actually new, so we must be starting to hit this code path now. FWIW, it doesn't seem to affect our rendering of the OpenAPI spec.

There's another `print` in line 525 which we haven't hit but perhaps should be removed at the same time.