### PR TITLE
adds test that illustrates invalid schema creation - embedded recursive type in an optional array, just to be extra difficult

### DIFF
--- a/Tests/SwiftOpenAPITests/ArrayDecodingTests.swift
+++ b/Tests/SwiftOpenAPITests/ArrayDecodingTests.swift
@@ -42,6 +42,12 @@ class ArrayDecodingTests: XCTestCase {
         _ = try ReferenceOr<SchemaObject>.encodeSchema(ProductDependency.example, into: &schemas)
         XCTAssertNoDifference(schemas, ["ProductDependency": .value(ProductDependency.scheme)])
     }
+
+    func testDecodeEmbeddedRecursiveOptionalArray() throws {
+        var schemas: ComponentsMap<SchemaObject> = [:]
+        let _ = try ReferenceOr<SchemaObject>.encodeSchema(EmbeddedOptionalRecursiveTypeInArray.example, into: &schemas)
+        XCTAssertNoDifference(schemas, ["ProductDependency": .value(ProductDependency.scheme)])
+    }
 }
     
 enum Tag {
@@ -55,6 +61,24 @@ enum Tag {
     struct ListResponse: Codable {
         let tags: [Response]
     }
+}
+
+public struct EmbeddedOptionalRecursiveTypeInArray: Codable, Equatable {
+    public var name: String
+    public var dependencies: [ProductDependency]?
+
+    public static let example = EmbeddedOptionalRecursiveTypeInArray(
+        name: "DTOExample",
+        dependencies: [ProductDependency.example]
+    )
+
+    static let scheme: SchemaObject = .object(
+        properties: [
+            "name": .string,
+            "dependencies": .array(of: .ref(components: \.schemas, "ProductDependency"))
+        ],
+        required: ["name"]
+    )
 }
 
 public struct ProductDependency: Codable, Equatable {


### PR DESCRIPTION
Hi @dankinsoid 

The fix you kindly made yesterday in response to https://github.com/dankinsoid/VaporToOpenAPI/issues/17 didn't do the trick, so I went back and dug further. Since it's using a Codable transformation, there's two additional complications that may be impacting this:

- the recursive type is embedded in another type
- where it's embedded is as an Optional Array, just not an array or instance, just to be extraordinarily difficult.

I tracked back the changes you made, and expanding the test suite to illustrate the failing scenario (although I don't know that I have the structure of the _expected_ schema entirely correct). At a minimum, this test fails showing the rendering where it's calling it `ArrayProductDependency`, so I'm hoping it's a bit of a jump.

I'll dig further to understand this project so I can hopefully help propose a solution, but wanted to at least make this effect available.