### PR TITLE
Update Package@swift-5.9.swift

### DIFF
--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -17,7 +17,7 @@ let package = Package(
 	],
 	dependencies: [
 		.package(url: "https://github.com/pointfreeco/swift-custom-dump.git", from: "0.10.3"),
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.2")
+                .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "509.0.2")
 	],
 	targets: [
 		.target(


### PR DESCRIPTION
Fixes warnings in downstream projects:


Showing All Messages

SwiftOpenAPI
'swiftopenapi' dependency on 'https://github.com/apple/swift-syntax.git' conflicts with dependency on 'https://github.com/swiftlang/swift-syntax' which has the same identity 'swift-syntax'. this will be escalated to an error in future versions of SwiftPM.