### PR TITLE
Fix pointing to the method in CaseIterable.Type

### DIFF
--- a/Sources/SwiftOpenAPI/Encoders/TypeRevision/TypeRevisionDecoder.swift
+++ b/Sources/SwiftOpenAPI/Encoders/TypeRevision/TypeRevisionDecoder.swift
@@ -107,13 +107,15 @@ final class TypeRevisionDecoder: Decoder {
 				result.container = .single(.string(nil))
 				result.type = type
 				return Data()
-			case let iterable as any CaseIterable.Type:
-				result.type = type
-				let allCases = iterable.allCases as any Collection
-				if let result = (allCases.first as? Decodable) ?? decodable {
-					return result
-				}
-				throw AnyError("Cannot decode CaseIterable \(type) type with an empty allCases")
+            case let iterable as any CaseIterable.Type:
+                result.type = type
+                guard
+                    let typedAll = iterable.allCases as? [Decodable],
+                    let first = typedAll.first
+                else {
+                    throw AnyError("Cannot decode CaseIterable \(type) with an empty allCases")
+                }
+                return first
 			default:
 				if case .keyed = result.container {
 					let decoder = CheckAllKeysDecoder()


### PR DESCRIPTION
Fix `.first` collision for `CaseIterable.Type` by casting to concrete Collection

Hi, I found a bug in `TypeRevisionDecoder` where casting `allCases` to `any Collection` causes `allCases.first as? Decodable` to fail. The Swift compiler interprets `.first` as referring to `first(where:)` instead of the property accessor, so it never actually returns the first element. This pull request fixes the issue by casting `allCases` to `[Decodable]` directly, ensuring `.first` points to the first element rather than a method reference.

Here are some screenshots from LLDB and Xcode illustrating the issue:

| LLDB Prints | Xcode With Docs |
|--------|--------|
| <img width="512" alt="Screenshot 2025-03-31 at 12 58 59" src="https://github.com/user-attachments/assets/2d891e1a-531b-41c9-bddb-7115f95a103e" /> | <img width="512" alt="Screenshot 2025-03-31 at 12 36 43" src="https://github.com/user-attachments/assets/b2abf762-fce5-48dc-a35e-3c85c4c23877" /> | 

With this change, `allCases.first` properly returns the first case as a Decodable.
