### PR TITLE
Replaced `OpenAPIDescriptionType?` with `(any OpenAPIDescriptionType)?'

### DIFF
--- a/Sources/SwiftOpenAPIMacros/OpenAPIDescriptionMacro.swift
+++ b/Sources/SwiftOpenAPIMacros/OpenAPIDescriptionMacro.swift
@@ -102,7 +102,7 @@ private func _expansion(
     let openAPIDescription: DeclSyntax =
       """
       
-      public static var openAPIDescription: OpenAPIDescriptionType? {
+      public static var openAPIDescription: (any OpenAPIDescriptionType)? {
           OpenAPIDescription<\(raw: type.rawValue)>(\(raw: typeDoc ?? ""))\(raw: varDocsModifiers)
       }
       """


### PR DESCRIPTION
use explicit existential syntax