### PR TITLE
Use range for Swift Syntax

### DIFF
--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -16,7 +16,7 @@ let package = Package(
 		.library(name: "SwiftOpenAPI", targets: ["SwiftOpenAPI"]),
 	],
 	dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0")
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0"..<"700.0.0"),
 	],
 	targets: [
 		.target(


### PR DESCRIPTION
Currently this package only accepts any minor version of Swift Syntax 600. This change enables a wide range of major Swift Syntax versions. 

This article does a great job of explaining why this is useful.
https://www.pointfree.co/blog/posts/116-being-a-good-citizen-in-the-land-of-swiftsyntax